### PR TITLE
BTAT-9357 Disabled AllowedHostsFilter

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -32,7 +32,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
 # Play Filters
 # ~~~~
 # Additional play filters can be added here
-
+play.filters.disabled += play.filters.hosts.AllowedHostsFilter
 
 # Global request handler
 # ~~~~


### PR DESCRIPTION
Since removing the bootstrap `BackendFilters`, the default Play `AllowedHostsFilter` is preventing deployment to the environments. The bootstrap filters previously disabled this but these filters are now deprecated, so this seems to be the best solution.